### PR TITLE
Add CMake install targets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(irlba INTERFACE
 target_compile_features(irlba INTERFACE cxx_std_17)
 
 # Dependencies
-option(IRLBA_FETCH_EXTERN "" ON)
+option(IRLBA_FETCH_EXTERN "Automatically fetch CppIrlba's dependencies." ON)
 if(IRLBA_FETCH_EXTERN)
     add_subdirectory(extern)
 else()
@@ -30,9 +30,9 @@ target_link_libraries(irlba INTERFACE Eigen3::Eigen ltla::aarand)
 
 # Tests
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-    option(IRLBA_TESTS "" ON)
+    option(IRLBA_TESTS "Build CppIrlba's test suite." ON)
 else()
-    option(IRLBA_TESTS "" OFF)
+    option(IRLBA_TESTS "Build CppIrlba's test suite." OFF)
 endif()
 if(IRLBA_TESTS)
     include(CTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,23 +1,60 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.14...3.25)
 
 project(irlba
     VERSION 1.0.0
     DESCRIPTION "C++ port of the IRLBA algorithm"
     LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
+# Dependencies
+option(IRLBA_FETCH_EXTERN "" ON)
+if(IRLBA_FETCH_EXTERN)
+    add_subdirectory(extern)
+else()
+    find_package(Eigen3 CONFIG REQUIRED)
+    find_package(ltla_aarand CONFIG REQUIRED)
+endif()
+
+# Library
 add_library(irlba INTERFACE)
+add_library(ltla::irlba ALIAS irlba)
 
-target_include_directories(irlba INTERFACE include/)
+target_include_directories(irlba INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/ltla>)
+target_compile_features(irlba INTERFACE cxx_std_17)
+target_link_libraries(irlba INTERFACE Eigen3::Eigen ltla::aarand)
 
-add_subdirectory(extern)
-
-target_link_libraries(irlba INTERFACE eigen aarand)
-
+# Tests
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    option(IRLBA_TESTS "" ON)
+else()
+    option(IRLBA_TESTS "" OFF)
+endif()
+if(IRLBA_TESTS)
     include(CTest)
     if(BUILD_TESTING)
         add_subdirectory(tests)
     endif()
 endif()
+
+# Install
+install(DIRECTORY include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/ltla)
+
+install(TARGETS irlba
+    EXPORT irlbaTargets)
+
+install(EXPORT irlbaTargets
+    FILE ltla_irlbaTargets.cmake
+    NAMESPACE ltla::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ltla_irlba)
+
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/ltla_irlbaConfig.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ltla_irlba)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/ltla_irlbaConfig.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ltla_irlba)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,15 @@ project(irlba
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
+# Library
+add_library(irlba INTERFACE)
+add_library(ltla::irlba ALIAS irlba)
+
+target_include_directories(irlba INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/ltla>)
+target_compile_features(irlba INTERFACE cxx_std_17)
+
 # Dependencies
 option(IRLBA_FETCH_EXTERN "" ON)
 if(IRLBA_FETCH_EXTERN)
@@ -17,14 +26,6 @@ else()
     find_package(ltla_aarand CONFIG REQUIRED)
 endif()
 
-# Library
-add_library(irlba INTERFACE)
-add_library(ltla::irlba ALIAS irlba)
-
-target_include_directories(irlba INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/ltla>)
-target_compile_features(irlba INTERFACE cxx_std_17)
 target_link_libraries(irlba INTERFACE Eigen3::Eigen ltla::aarand)
 
 # Tests

--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ See the [reference documentation](https://ltla.github.io/CppIrlba) for more deta
 
 ## Building projects
 
+### CMake with `FetchContent`
+
 If you're using CMake, you just need to add something like this to your `CMakeLists.txt`:
 
-```
+```cmake
 include(FetchContent)
 
 FetchContent_Declare(
@@ -57,13 +59,32 @@ FetchContent_MakeAvailable(irlba)
 
 Then you can link to **irlba** to make the headers available during compilation:
 
-```
+```cmake
 # For executables:
-target_link_libraries(myexe irlba)
+target_link_libraries(myexe ltla::irlba)
 
 # For libaries
-target_link_libraries(mylib INTERFACE irlba)
+target_link_libraries(mylib INTERFACE ltla::irlba)
 ```
+
+### CMake with `find_package()`
+
+```cmake
+find_package(ltla_irlba CONFIG REQUIRED)
+target_link_libraries(mylib INTERFACE ltla::irlba)
+```
+
+To install the library use:
+
+```sh
+mkdir build && cd build
+cmake .. -DIRLBA_TESTS=OFF
+cmake --build . --target install
+```
+
+If you want to install the dependencies [**Eigen**](https://gitlab.com/libeigen/eigen) and [**aarand**](https://github.com/LTLA/aarand) manually use `-DIRLBA_FETCH_EXTERN=OFF`.
+
+### Manual
 
 If you're not using CMake, the simple approach is to just copy the files - either directly or with Git submodules - and include their path during compilation with, e.g., GCC's `-I`.
 Note that this requires manual management of a few dependencies:

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ cmake .. -DIRLBA_TESTS=OFF
 cmake --build . --target install
 ```
 
-If you want to install the dependencies [**Eigen**](https://gitlab.com/libeigen/eigen) and [**aarand**](https://github.com/LTLA/aarand) manually use `-DIRLBA_FETCH_EXTERN=OFF`.
+By default, this will use `FetchContent` to fetch all external dependencies.
+If you want to install them manually, use `-DPOWERIT_FETCH_EXTERN=OFF`.
+See the commit hashes in [`extern/CMakeLists.txt`](extern/CMakeLists.txt) to find compatible versions of each dependency.
 
 ### Manual
 
@@ -91,6 +93,8 @@ Note that this requires manual management of a few dependencies:
 
 - [**Eigen**](https://gitlab.com/libeigen/eigen), for matrix manipulations.
 - [**aarand**](https://github.com/LTLA/aarand), for system-agnostic random distribution functions.
+
+See [`extern/CMakeLists.txt`](extern/CMakeLists.txt) for more details.
 
 ## References
 

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+find_dependency(Eigen3 CONFIG REQUIRED)
+find_dependency(ltla_aarand CONFIG REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/ltla_irlbaTargets.cmake")

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -13,7 +13,7 @@ FetchContent_MakeAvailable(eigen)
 FetchContent_Declare(
   aarand
   GIT_REPOSITORY https://github.com/LTLA/aarand
-  GIT_TAG bd06e0d52e59e35f0456a870746a959da4bc7cb3
+  GIT_TAG 84d48b65d49ce8b844398f11aff3015b86e17197
 )
 
 FetchContent_MakeAvailable(aarand)

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -13,7 +13,7 @@ FetchContent_MakeAvailable(eigen)
 FetchContent_Declare(
   aarand
   GIT_REPOSITORY https://github.com/LTLA/aarand
-  GIT_TAG f61f6b08453cfa8d2681f32b795626f8cd21c724
+  GIT_TAG bd06e0d52e59e35f0456a870746a959da4bc7cb3
 )
 
 FetchContent_MakeAvailable(aarand)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ FetchContent_Declare(
 
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+option(INSTALL_GTEST "" OFF)
 FetchContent_MakeAvailable(googletest)
 
 enable_testing()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,10 @@ FetchContent_Declare(
 
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-option(INSTALL_GTEST "" OFF)
+
+# Avoid installing GoogleTest when installing this project.
+option(INSTALL_GTEST "Enable installation of googletest." OFF)
+
 FetchContent_MakeAvailable(googletest)
 
 enable_testing()


### PR DESCRIPTION
Follow up to https://github.com/LTLA/aarand/pull/2.

Now with external dependencies required there is an additional option `IRLBA_FETCH_EXTERN` to switch between FetchContent (default) and find_package().