### PR TITLE
Begin migration to Eigen 5.0.0.

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -45,7 +45,7 @@ jobs:
     - name: Run the tests
       run: |
         cd build
-        ctest
+        ctest --rerun-failed --output-on-failure
 
     - name: Generate code coverage
       if: ${{ matrix.config.cov }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,12 +22,12 @@ option(IRLBA_FETCH_EXTERN "Automatically fetch CppIrlba's dependencies." ON)
 if(IRLBA_FETCH_EXTERN)
     add_subdirectory(extern)
 else()
-    find_package(Eigen3 3.4.0 CONFIG REQUIRED)
+    find_package(eigen 5.0.0 CONFIG REQUIRED)
     find_package(ltla_aarand 1.0.0 CONFIG REQUIRED)
     find_package(ltla_subpar 0.3.1 CONFIG REQUIRED)
 endif()
 
-target_link_libraries(irlba INTERFACE Eigen3::Eigen ltla::aarand ltla::subpar)
+target_link_libraries(irlba INTERFACE eigen ltla::aarand ltla::subpar)
 
 # Tests
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,12 +22,12 @@ option(IRLBA_FETCH_EXTERN "Automatically fetch CppIrlba's dependencies." ON)
 if(IRLBA_FETCH_EXTERN)
     add_subdirectory(extern)
 else()
-    find_package(eigen 5.0.0 CONFIG REQUIRED)
+    find_package(Eigen3 5.0.0 CONFIG REQUIRED)
     find_package(ltla_aarand 1.0.0 CONFIG REQUIRED)
     find_package(ltla_subpar 0.3.1 CONFIG REQUIRED)
 endif()
 
-target_link_libraries(irlba INTERFACE eigen ltla::aarand ltla::subpar)
+target_link_libraries(irlba INTERFACE Eigen3::Eigen ltla::aarand ltla::subpar)
 
 # Tests
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,7 +1,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(Eigen3 3.4.0 CONFIG REQUIRED)
+find_dependency(eigen 5.0.0 CONFIG REQUIRED)
 find_dependency(ltla_aarand 1.0.0 CONFIG REQUIRED)
 find_dependency(ltla_subpar 0.3.1 CONFIG REQUIRED)
 

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,7 +1,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(eigen 5.0.0 CONFIG REQUIRED)
+find_dependency(Eigen3 5.0.0 CONFIG REQUIRED)
 find_dependency(ltla_aarand 1.0.0 CONFIG REQUIRED)
 find_dependency(ltla_subpar 0.3.1 CONFIG REQUIRED)
 

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -5,7 +5,7 @@ include(FetchContent)
 FetchContent_Declare(
   eigen 
   GIT_REPOSITORY https://gitlab.com/libeigen/eigen
-  GIT_TAG 3.4.0
+  GIT_TAG 5.0.0
 )
 
 FetchContent_Declare(
@@ -20,6 +20,10 @@ FetchContent_Declare(
   GIT_TAG master # ^0.3.1
 )
 
+# Forcing the Eigen build to create the installation files,
+# otherwise irlba's own installation gets confused.
+option(EIGEN_BUILD_CMAKE_PACKAGE "Build the Eigen Cmake package" ON)
 FetchContent_MakeAvailable(eigen)
+
 FetchContent_MakeAvailable(aarand)
 FetchContent_MakeAvailable(subpar)

--- a/tests/src/EigenThreadScope.cpp
+++ b/tests/src/EigenThreadScope.cpp
@@ -2,6 +2,16 @@
 
 #include "irlba/parallel.hpp"
 
+#ifdef IRLBA_CUSTOM_PARALLEL
+#ifdef IRLBA_CUSTOM_PARALLEL_USES_OPENMP
+#include "omp.h"
+#endif
+#else
+#ifndef SUBPAR_NO_OPENMP_SIMPLE
+#include "omp.h"
+#endif
+#endif
+
 TEST(EigenThreadScope, Basic) {
     int old = Eigen::nbThreads();
 
@@ -10,7 +20,7 @@ TEST(EigenThreadScope, Basic) {
 
 #ifdef IRLBA_CUSTOM_PARALLEL
 #ifdef IRLBA_CUSTOM_PARALLEL_USES_OPENMP
-        EXPECT_EQ(Eigen::nbThreads(), 10);
+        EXPECT_EQ(Eigen::nbThreads(), std::min(10, omp_get_max_threads()));
 #else
         EXPECT_EQ(Eigen::nbThreads(), 1);
 #endif
@@ -18,7 +28,7 @@ TEST(EigenThreadScope, Basic) {
 #ifdef SUBPAR_NO_OPENMP_SIMPLE
         EXPECT_EQ(Eigen::nbThreads(), 1);
 #else
-        EXPECT_EQ(Eigen::nbThreads(), 10);
+        EXPECT_EQ(Eigen::nbThreads(), std::min(10, omp_get_max_threads()));
 #endif
 #endif
     }

--- a/tests/src/compute.cpp
+++ b/tests/src/compute.cpp
@@ -20,7 +20,7 @@ TEST(IrlbaTest, CompareToExact) {
     opt.exact_for_large_number = false;
     auto res = irlba::compute(A, 5, opt);
 
-    Eigen::JacobiSVD svd(A, Eigen::ComputeThinU | Eigen::ComputeThinV);
+    Eigen::JacobiSVD<decltype(A), Eigen::ComputeThinU | Eigen::ComputeThinV> svd(A);
     expect_equal_vectors(res.D, svd.singularValues().head(rank), 1e-8);
     expect_equal_column_vectors(res.U, svd.matrixU().leftCols(rank), 1e-8);
     expect_equal_column_vectors(res.V, svd.matrixV().leftCols(rank), 1e-8);
@@ -51,7 +51,7 @@ TEST_P(IrlbaTester, Basic) {
     ASSERT_EQ(res.D.size(), rank);
 
     // Gives us singular values that are around about right.
-    Eigen::JacobiSVD svd(A, Eigen::ComputeThinU | Eigen::ComputeThinV);
+    Eigen::JacobiSVD<decltype(A), Eigen::ComputeThinU | Eigen::ComputeThinV> svd(A);
     expect_equal_vectors(res.D, svd.singularValues().head(rank), 1e-6);
     expect_equal_column_vectors(res.U, svd.matrixU().leftCols(rank), 1e-6);
     expect_equal_column_vectors(res.V, svd.matrixV().leftCols(rank), 1e-6);
@@ -68,6 +68,10 @@ TEST_P(IrlbaTester, Basic) {
     opt.initial = &init;
     auto res2 = irlba::compute(A, rank, opt);
     expect_equal_vectors(res.D, res2.D, 1e-6);
+
+    // Checking that all of our SFINAE checks hold up.
+    constexpr bool can_svd = irlba::internal::can_svd<Eigen::MatrixXd, decltype(A)>::value;
+    EXPECT_TRUE(can_svd);
 }
 
 std::vector<Eigen::MatrixXd> spawn_center_scale(const Eigen::MatrixXd& A) {
@@ -153,7 +157,7 @@ TEST(IrlbaTest, SmallExact) {
 
     auto res = irlba::compute(small, 2, irlba::Options());
 
-    Eigen::JacobiSVD svd(small, Eigen::ComputeThinU | Eigen::ComputeThinV);
+    Eigen::JacobiSVD<decltype(small), Eigen::ComputeThinU | Eigen::ComputeThinV> svd(small);
     EXPECT_EQ(svd.singularValues().head(2), res.D);
     EXPECT_EQ(svd.matrixU().leftCols(2), res.U);
     EXPECT_EQ(svd.matrixV().leftCols(2), res.V);
@@ -165,7 +169,7 @@ TEST(IrlbaTest, LargeExact) {
     irlba::Options opt;
     auto res = irlba::compute(mat, 15, opt);
 
-    Eigen::JacobiSVD svd(mat, Eigen::ComputeThinU | Eigen::ComputeThinV);
+    Eigen::JacobiSVD<decltype(mat), Eigen::ComputeThinU | Eigen::ComputeThinV> svd(mat);
     EXPECT_EQ(svd.singularValues().head(15), res.D);
     EXPECT_EQ(svd.matrixU().leftCols(15), res.U);
     EXPECT_EQ(svd.matrixV().leftCols(15), res.V);

--- a/tests/src/sparse.cpp
+++ b/tests/src/sparse.cpp
@@ -48,6 +48,10 @@ TEST_F(SparseTester, Sparse) {
     expect_equal_vectors(res.D, res2.D);
     expect_equal_column_vectors(res.U, res2.U);
     expect_equal_column_vectors(res.V, res2.V);
+
+    // Checking that all of our SFINAE checks hold up.
+    constexpr bool can_svd = irlba::internal::can_svd<Eigen::MatrixXd, decltype(B)>::value;
+    EXPECT_FALSE(can_svd);
 }
 
 TEST_F(SparseTester, CenterScale) {
@@ -76,7 +80,7 @@ TEST_F(SparseTester, SparseToReference) {
     auto res = irlba::compute(B, 13, opt);
 
     // Bumping up the tolerance as later SV's tend to be a bit more variable.
-    Eigen::JacobiSVD svd(A, Eigen::ComputeThinU | Eigen::ComputeThinV);
+    Eigen::JacobiSVD<decltype(A), Eigen::ComputeThinU | Eigen::ComputeThinV> svd(A);
     expect_equal_vectors(res.D, svd.singularValues().head(13), 1e-5);
     expect_equal_column_vectors(res.U, svd.matrixU().leftCols(13), 1e-5);
     expect_equal_column_vectors(res.V, svd.matrixV().leftCols(13), 1e-5);


### PR DESCRIPTION
This requires some fiddling with Cmake to get Eigen to build the install files, otherwise we can't install Irlba itself by default.

Also, our heuristic to detect Eigen matrices doesn't work as well as it should anymore, so we need to change it to get it to pass.