### PR TITLE
Choose better integer types and protect against integer overflow.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,10 @@ else()
     find_package(Eigen3 5.0.0 CONFIG REQUIRED)
     find_package(ltla_aarand 1.0.0 CONFIG REQUIRED)
     find_package(ltla_subpar 0.3.1 CONFIG REQUIRED)
+    find_package(ltla_sanisizer 0.1.0 CONFIG REQUIRED)
 endif()
 
-target_link_libraries(irlba INTERFACE Eigen3::Eigen ltla::aarand ltla::subpar)
+target_link_libraries(irlba INTERFACE Eigen3::Eigen ltla::aarand ltla::subpar ltla::sanisizer)
 
 # Tests
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -4,5 +4,6 @@ include(CMakeFindDependencyMacro)
 find_dependency(Eigen3 5.0.0 CONFIG REQUIRED)
 find_dependency(ltla_aarand 1.0.0 CONFIG REQUIRED)
 find_dependency(ltla_subpar 0.3.1 CONFIG REQUIRED)
+find_dependency(ltla_sanisizer 0.1.0 CONFIG REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/ltla_irlbaTargets.cmake")

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -20,6 +20,12 @@ FetchContent_Declare(
   GIT_TAG master # ^0.3.1
 )
 
+FetchContent_Declare(
+  sanisizer
+  GIT_REPOSITORY https://github.com/LTLA/sanisizer
+  GIT_TAG master # ^0.1.3
+)
+
 # Forcing the Eigen build to create the installation files,
 # otherwise irlba's own installation gets confused.
 option(EIGEN_BUILD_CMAKE_PACKAGE "Build the Eigen Cmake package" ON)
@@ -27,3 +33,4 @@ FetchContent_MakeAvailable(eigen)
 
 FetchContent_MakeAvailable(aarand)
 FetchContent_MakeAvailable(subpar)
+FetchContent_MakeAvailable(sanisizer)

--- a/include/irlba/Options.hpp
+++ b/include/irlba/Options.hpp
@@ -69,7 +69,7 @@ struct Options {
     /**
      * Seed for the creation of random vectors, primarily during initialization of the IRLBA algorithm.
      */
-    uint64_t seed = std::mt19937_64::default_seed;
+    typename std::mt19937_64::result_type seed = std::mt19937_64::default_seed;
 
     /**
      * Pointer to an `EigenVector_` (see `compute()`) containing the initial values of the first right singular vector.

--- a/include/irlba/lanczos.hpp
+++ b/include/irlba/lanczos.hpp
@@ -62,10 +62,10 @@ void run_lanczos_bidiagonalization(
     const Options& options) 
 {
     typedef typename EigenMatrix_::Scalar Float;
-    Float raw_eps = options.invariant_subspace_tolerance;
-    Float eps = (raw_eps < 0 ? std::pow(std::numeric_limits<Float>::epsilon(), 0.8) : raw_eps);
+    const Float raw_eps = options.invariant_subspace_tolerance;
+    const Float eps = (raw_eps < 0 ? std::pow(std::numeric_limits<Float>::epsilon(), 0.8) : raw_eps);
 
-    Eigen::Index work = W.cols();
+    const Eigen::Index work = W.cols();
     auto& F = inter.F;
     auto& W_next = inter.W_next;
     auto& otmp = inter.orthog_tmp;
@@ -88,7 +88,8 @@ void run_lanczos_bidiagonalization(
     // The Lanczos iterations themselves, see algorithm 2.1 of Baglama and Reichel.
     for (Eigen::Index j = start; j < work; ++j) {
         // This step is equivalent to F = mat.adjoint() * W.col(j).
-        // This is because W_next is assigned into W.col(start) at the start, or W.col(j+1) from the previous iteration.
+        // Remember that W_next is assigned into W.col(start) at the start, or W.col(j+1) from the previous iteration;
+        // so W_next is equal to W.col(j) in the current iteration.
         inter.awork->multiply(W_next, F); 
 
         F -= S * V.col(j); // equivalent to daxpy.

--- a/include/irlba/pca.hpp
+++ b/include/irlba/pca.hpp
@@ -68,8 +68,8 @@ std::pair<bool, int> pca(
         return compute<Interface>(wrapped, number, outU, outV, outD, options);
     }
 
-    auto nr = matrix.rows();
-    auto nc = matrix.cols();
+    const Eigen::Index nr = matrix.rows();
+    const Eigen::Index nc = matrix.cols();
 
     EigenVector_ center0;
     if (center) {
@@ -88,7 +88,7 @@ std::pair<bool, int> pca(
     }
 
     for (Eigen::Index i = 0; i < nc; ++i) {
-        double mean = 0;
+        typename EigenVector_::Scalar mean = 0;
         if (center) {
             mean = matrix.col(i).sum() / nr;
             center0[i] = mean;
@@ -140,7 +140,7 @@ std::pair<bool, int> pca(
 template<class OutputEigenMatrix_ = Eigen::MatrixXd, class EigenVector_ = Eigen::VectorXd, class InputEigenMatrix_>
 Results<OutputEigenMatrix_, EigenVector_> pca(const InputEigenMatrix_& matrix, bool center, bool scale, Eigen::Index number, const Options& options) {
     Results<OutputEigenMatrix_, EigenVector_> output;
-    auto stats = pca(matrix, center, scale, number, output.U, output.V, output.D, options);
+    const auto stats = pca(matrix, center, scale, number, output.U, output.V, output.D, options);
     output.converged = stats.first;
     output.iterations = stats.second;
     return output;

--- a/include/irlba/utils.hpp
+++ b/include/irlba/utils.hpp
@@ -15,17 +15,24 @@ using I = typename std::remove_cv<typename std::remove_reference<Input_>::type>:
 
 template<class EigenVector_, class Engine_>
 void fill_with_random_normals(EigenVector_& vec, Engine_& eng) {
-    Eigen::Index i = 1, limit = vec.size();
-    while (i < limit) {
-        auto paired = aarand::standard_normal<typename EigenVector_::Scalar>(eng);
-        vec[i - 1] = paired.first;
-        vec[i] = paired.second;
-        i += 2;
+    auto num_total = vec.size();
+    const bool odd = num_total % 2;
+    if (odd) {
+        --num_total;
     }
 
-    if (i == limit) {
-        auto paired = aarand::standard_normal(eng);
-        vec[i - 1] = paired.first;
+    // Box-Muller gives us two random values at a time.
+    typedef typename EigenVector_::Scalar Float;
+    for (I<decltype(num_total)> i = 0; i < num_total; i += 2) {
+        const auto paired = aarand::standard_normal<Float>(eng);
+        vec[i] = paired.first;
+        vec[i + 1] = paired.second;
+    }
+
+    if (odd) {
+        // Adding the poor extra for odd total lengths.
+        auto paired = aarand::standard_normal<Float>(eng);
+        vec[num_total] = paired.first;
     }
 }
 

--- a/tests/src/Matrix/sparse.cpp
+++ b/tests/src/Matrix/sparse.cpp
@@ -53,10 +53,10 @@ TEST_P(ParallelSparseMatrixTest, Basic) {
     EXPECT_EQ(A.get_values().size(), values.size());
     EXPECT_EQ(A.get_pointers().size(), nc + 1);
     if (nt > 1) {
-        EXPECT_EQ(A.get_primary_starts().size(), nt);
-        EXPECT_EQ(A.get_primary_ends().size(), nt);
-        EXPECT_EQ(A.get_secondary_nonzero_starts().size(), nt + 1);
-        EXPECT_EQ(A.get_secondary_nonzero_starts().front().size(), nc);
+        EXPECT_EQ(A.get_primary_boundaries().size(), nt + 1);
+        EXPECT_EQ(A.get_secondary_boundaries().size(), nt + 1);
+        EXPECT_EQ(A.get_secondary_nonzero_boundaries().size(), nt + 1);
+        EXPECT_EQ(A.get_secondary_nonzero_boundaries().front().size(), nc);
     }
 
     irlba::ParallelSparseMatrix<Eigen::VectorXd, Eigen::MatrixXd, decltype(values), decltype(indices), decltype(nzeros)> A2(nc, nr, values, indices, nzeros, false, nt);


### PR DESCRIPTION
This mostly affects compute() and ParallelSparseMatrix, where some of the arithmetic and implicit casts for allocations were a bit too relaxed. We add a dependency on the sanisizer library to ensure that these calculations are ok.

We improve the worksharing across threads in ParallelSparseMatrix, and we refactor the primary starts/ends into a single vector to reduce memory usage. This involves some renaming of the getters for the per-thread data structures.

Finally, we slapped const on everything to indicate immutability.